### PR TITLE
removing keydown event listener

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -578,16 +578,6 @@ class VLWholeSlideMicroscopyImageViewer {
     scaleInnerElement.style.margin = '1px';
     scaleInnerElement.style.willChange = 'contents,width';
 
-    document.addEventListener('keydown', ((e) => {
-        const key = e.key;
-        if (key === "Escape") {
-          this.deactivateDrawInteraction();
-          this.deactivateSelectInteraction();
-          this.deactivateModifyInteraction();
-          mapElement.style.cursor = 'default';
-        }
-    }));
-
   }
 
   /* Activate draw interaction.


### PR DESCRIPTION
### What
key down event listener was removed

### Why
Currently, when users start drawing and press escape it generates an error as the issue https://github.com/dcmjs-org/dicom-microscopy-viewer/issues/16 