### PR TITLE
Add UID to ROI objects

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -43,13 +43,14 @@ import DICOMwebClient from 'dicomweb-client/build/dicomweb-client.js'
 
 
 function _geometry2Scoord3d(geometry, pyramid) {
+  const referencedFrameOfReferenceUID = pyramid[pyramid.length-1].frameOfReferenceUID;
   const type = geometry.getType();
   if (type === 'Point') {
     let coordinates = geometry.getCoordinates();
     coordinates = _geometryCoordinates2scoord3dCoordinates(coordinates, pyramid);
     return new Point({
       coordinates,
-      referencedFrameOfReferenceUID: pyramid[pyramid.length-1].frameOfReferenceUID
+      referencedFrameOfReferenceUID: referencedFrameOfReferenceUID
     });
   } else if (type === 'Polygon') {
     /*
@@ -61,7 +62,7 @@ function _geometry2Scoord3d(geometry, pyramid) {
     });
     return new Polygon({
       coordinates,
-      referencedFrameOfReferenceUID: pyramid[pyramid.length-1].frameOfReferenceUID
+      referencedFrameOfReferenceUID: referencedFrameOfReferenceUID
     });
   } else if (type === 'LineString') {
     let coordinates = geometry.getCoordinates().map(c => {
@@ -69,7 +70,7 @@ function _geometry2Scoord3d(geometry, pyramid) {
     });
     return new Polyline({
       coordinates,
-      referencedFrameOfReferenceUID: pyramid[pyramid.length-1].frameOfReferenceUID
+      referencedFrameOfReferenceUID: referencedFrameOfReferenceUID
     });
   } else if (type === 'Circle') {
     // chunking the Flat Coordinates into two arrays within 3 elements each
@@ -84,7 +85,7 @@ function _geometry2Scoord3d(geometry, pyramid) {
     })
     return new Circle({
       coordinates,
-      referencedFrameOfReferenceUID: pyramid[pyramid.length-1].frameOfReferenceUID
+      referencedFrameOfReferenceUID: referencedFrameOfReferenceUID
     });
   } else {
     // TODO: Combine multiple points into MULTIPOINT.

--- a/src/api.js
+++ b/src/api.js
@@ -833,11 +833,9 @@ class VLWholeSlideMicroscopyImageViewer {
 
   getAllROIs() {
     let rois = [];
-    if (this.numberOfROIs > 0) {
-      for(let index = 0; index < this.numberOfROIs; index++){
-        rois.push(this.getROI(index));
-      }
-    }
+    this[_features].forEach((item) => {
+        rois.push(this.getROI(item.getId()));
+    });
     return rois;
   }
 
@@ -845,18 +843,9 @@ class VLWholeSlideMicroscopyImageViewer {
     return this[_features].getLength();
   }
 
-  getROI(index) {
-    const feature = this[_features].item(index);
+  getROI(uid) {
+    const feature = this[_drawingSource].getFeatureById(uid);
     return _getROIFromFeature(feature, this._pyramid);
-  }
-
-  indexOfROI(item) {
-    for(let index = 0; index < this.numberOfROIs; index++){
-      if (item.uid === this[_features].item(index).getId()) {
-        return index;
-      }
-    }
-    return -1;
   }
 
   popROI() {
@@ -868,19 +857,17 @@ class VLWholeSlideMicroscopyImageViewer {
     const geometry = _scoord3d2Geometry(item.scoord3d, this._pyramid);
     const feature = new Feature(geometry);
     feature.setProperties(item.properties, true);
+    feature.setId(item.uid);
     this[_features].push(feature);
   }
 
-  updateROI(index, item) {
-    const geometry = _scoord3d2Geometry(item.scoord3d, this._pyramid);
-    const feature = new Feature(geometry);
-    feature.setProperties(item.properties, true);
-    feature.setId(item.uid);
-    this[_features].setAt(index, feature);
+  removeROI(uid) {
+    const feature = this[_drawingSource].getFeatureById(uid);
+    this[_features].remove(feature);
   }
 
-  removeROI(index) {
-    this[_features].removeAt(index);
+  removeAllROI() {
+    this[_features].clear();
   }
 
   hideROIs() {

--- a/src/api.js
+++ b/src/api.js
@@ -29,6 +29,7 @@ import { toStringXY } from 'ol/coordinate';
 
 import { formatImageMetadata } from './metadata.js';
 import { ROI } from './roi.js';
+import { generateUuid } from './utils.js';
 import {
   Point,
   Multipoint,
@@ -39,6 +40,7 @@ import {
 } from './scoord3d.js';
 
 import DICOMwebClient from 'dicomweb-client/build/dicomweb-client.js'
+
 
 function _geometry2Scoord3d(geometry, pyramid) {
   const type = geometry.getType();
@@ -160,7 +162,8 @@ function _getROIFromFeature(feature, pyramid){
     // Remove geometry from properties mapping
     const geometryName = feature.getGeometryName();
     delete properties[geometryName];
-    roi = new ROI({scoord3d, properties});
+    const uid = feature.getId();
+    roi = new ROI({scoord3d, properties, uid});
   }
   return roi;
 }
@@ -208,6 +211,14 @@ class VLWholeSlideMicroscopyImageViewer {
 
     // Collection of Openlayers "Feature" instances
     this[_features] = new Collection([], {unique: true});
+    // Add unique identifier to each created "Feature" instance
+    this[_features].on('add', (e) => {
+      // The ID may have already been set when drawn. However, features could
+      // have also been added without a draw event.
+      if (e.element.getId() === undefined) {
+        e.element.setId(generateUuid());
+      }
+    });
 
     /*
      * To visualize images accross multiple scales, we first need to
@@ -711,6 +722,7 @@ class VLWholeSlideMicroscopyImageViewer {
 
     //attaching openlayers events handling
     this[_interactions].draw.on('drawend', (e) => {
+      e.feature.setId(generateUuid());
       publish(container, EVENT.ROI_DRAWN, _getROIFromFeature(e.feature, this._pyramid));
     });
 
@@ -800,22 +812,12 @@ class VLWholeSlideMicroscopyImageViewer {
 
   getROI(index) {
     const feature = this[_features].item(index);
-    let roi = _getROIFromFeature(feature, this._pyramid);
-    return roi;
+    return _getROIFromFeature(feature, this._pyramid);
   }
-
-  // getROIIndex(item) {
-  //   this[_features].
-  // }
 
   popROI() {
     const feature = this[_features].pop();
-    const geometry = feature.getGeometry()
-    const scoord3d = _geometry2Scoord3d(geometry, this._pyramid);
-    const properties = feature.getProperties();
-    const geometryName = feature.getGeometryName();
-    delete properties[geometryName];
-    return new ROI({scoord3d, properties});
+    return _getROIFromFeature(feature, this._pyramid);
   }
 
   addROI(item) {

--- a/src/dicom-microscopy-viewer.js
+++ b/src/dicom-microscopy-viewer.js
@@ -5,7 +5,7 @@ import {
   Multipoint,
   Polyline,
   Polygon,
-  Circle,
+  Ellipsoid,
   Ellipse,
 } from './scoord3d.js';
 
@@ -17,7 +17,7 @@ let scoord3d = {
   Multipoint,
   Polyline,
   Polygon,
-  Circle,
+  Ellipsoid,
   Ellipse
 };
 let roi = {

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -40,6 +40,7 @@ function formatImageMetadata(metadata) {
   }
 
   const imageOrientationSlide = metadata['00480102']['Value'];
+  const frameOfReferenceUID = metadata['00200052']['Value'][0];
 
   let tilesPerRow = Math.ceil(totalPixelMatrixColumns / columns);
   let tilesPerColumn = Math.ceil(totalPixelMatrixRows / rows);
@@ -93,6 +94,7 @@ function formatImageMetadata(metadata) {
     imageVolumeHeight,
     pixelSpacing,
     imageOrientationSlide,
+    frameOfReferenceUID,
     frameMapping
   });
 }

--- a/src/roi.js
+++ b/src/roi.js
@@ -1,3 +1,5 @@
+import { generateUuid } from './utils.js';
+
 /* Region of interest.
  */
 class ROI {
@@ -9,6 +11,11 @@ class ROI {
   constructor(options) {
     if (!('scoord3d' in options)) {
       console.error('spatial coordinates are required for ROI')
+    }
+    if (!('uid' in options)) {
+      this.uid = generateUuid();
+    } else {
+      this.uid = options.uid;
     }
     this.scoord3d = options.scoord3d;
     this.properties = options.properties ? options.properties : {};

--- a/src/roi.js
+++ b/src/roi.js
@@ -16,6 +16,9 @@ class ROI {
     if (!('uid' in options)) {
       this.uid = generateUuid();
     } else {
+      if (!(typeof options.uid === 'string' || options.uid instanceof String)) {
+        throw new Error('uid of ROI must be a string')
+      }
       this.uid = options.uid;
     }
     this.scoord3d = options.scoord3d;

--- a/src/roi.js
+++ b/src/roi.js
@@ -1,5 +1,6 @@
 import { generateUuid } from './utils.js';
 
+
 /* Region of interest.
  */
 class ROI {

--- a/src/roi.js
+++ b/src/roi.js
@@ -1,4 +1,4 @@
-import { generateUuid } from './utils.js';
+import { generateUID } from './utils.js';
 
 
 /* Region of interest.
@@ -14,7 +14,7 @@ class ROI {
       console.error('spatial coordinates are required for ROI')
     }
     if (!('uid' in options)) {
-      this.uid = generateUuid();
+      this.uid = generateUID();
     } else {
       if (!(typeof options.uid === 'string' || options.uid instanceof String)) {
         throw new Error('uid of ROI must be a string')

--- a/src/scoord3d.js
+++ b/src/scoord3d.js
@@ -7,10 +7,17 @@ const _majorAxisEndpointCoordinates = Symbol('majorAxisEndpointCoordinates')
 const _minorAxisEndpointCoordinates = Symbol('minorAxisEndpointCoordinates')
 const _centerCoordinates = Symbol('centerCoordinates')
 const _radius = Symbol('radius')
+const _referencedFrameOfReferenceUID = Symbol('referencedFrameOfReferenceUID')
 
 class Scoord3D {
 
-  constructor() {}
+  constructor(options) {
+    if (!(typeof options.referencedFrameOfReferenceUID === 'string' ||
+          options.referencedFrameOfReferenceUID instanceof String)) {
+      throw new Error('referencedFrameOfReferenceUID of Scoord3D must be a string')
+    }
+    this[_referencedFrameOfReferenceUID] = options.referencedFrameOfReferenceUID
+  }
 
   get graphicData() {
     throw new Error('Prototype property "graphicData" must be implemented.')
@@ -21,27 +28,22 @@ class Scoord3D {
   }
 
   get referencedFrameOfReferenceUID() {
-    throw new Error('Prototype property "referencedFrameOfReferenceUID" must be implemented.')
-  }
-
-  get fiducialUID() {
-    throw new Error('Prototype property "fiducialUID" must be implemented.')
+    return this[_referencedFrameOfReferenceUID]
   }
 
 }
 
 class Point extends Scoord3D {
-  
-  
-  constructor(coordinates) {
-    super()
-    if (!Array.isArray(coordinates)) {
+
+  constructor(options) {
+    super({referencedFrameOfReferenceUID: options.referencedFrameOfReferenceUID})
+    if (!Array.isArray(options.coordinates)) {
       throw new Error('coordinates of Point must be an array')
     }
-    if (coordinates.length !== 3) {
+    if (options.coordinates.length !== 3) {
       throw new Error('coordinates of Point must be an array of length 3')
     }
-    this[_coordinates] = coordinates
+    this[_coordinates] = options.coordinates
   }
 
   get graphicData() {
@@ -56,15 +58,15 @@ class Point extends Scoord3D {
 
 class Multipoint extends Scoord3D {
 
-  constructor(coordinates) {
-    super()
-    if (!Array.isArray(coordinates)) {
+  constructor(options) {
+    super({referencedFrameOfReferenceUID: options.referencedFrameOfReferenceUID})
+    if (!Array.isArray(options.coordinates)) {
       throw new Error('coordinates of Multipoint must be an array')
     }
-    if(coordinates.find(c => c.length !== 3)!== undefined){
+    if(options.coordinates.find(c => c.length !== 3)!== undefined){
       throw new Error('coordinates of Multipoint must be an array of length 3')
     }
-    this[_coordinates] = coordinates
+    this[_coordinates] = options.coordinates
   }
 
   get graphicData() {
@@ -79,15 +81,15 @@ class Multipoint extends Scoord3D {
 
 class Polyline extends Scoord3D {
 
-  constructor(coordinates) {
-    super()
-    if (!Array.isArray(coordinates)) {
+  constructor(options) {
+    super({referencedFrameOfReferenceUID: options.referencedFrameOfReferenceUID})
+    if (!Array.isArray(options.coordinates)) {
       throw new Error('coordinates of Polyline must be an array')
     }
-    if(coordinates.find(c => c.length !== 3)!== undefined){
+    if(options.coordinates.find(c => c.length !== 3)!== undefined){
       throw new Error('coordinates of Polyline must be a list of points of length 3')
     }
-    this[_coordinates] = coordinates
+    this[_coordinates] = options.coordinates
   }
 
   get graphicData() {
@@ -107,15 +109,15 @@ class Polyline extends Scoord3D {
 
 class Polygon extends Scoord3D {
 
-  constructor(coordinates) {
-    super()
-    if (!Array.isArray(coordinates)) {
+  constructor(options) {
+    super({referencedFrameOfReferenceUID: options.referencedFrameOfReferenceUID})
+    if (!Array.isArray(options.coordinates)) {
       throw new Error('coordinates of Polygon must be an array')
     }
-    if(coordinates.find(c => c.length !== 3)!== undefined){
+    if(options.coordinates.find(c => c.length !== 3)!== undefined){
       throw new Error('coordinates of Polygon must be a list of points of length 3')
     }
-    this[_coordinates] = coordinates
+    this[_coordinates] = options.coordinates
   }
 
   get graphicData() {
@@ -135,18 +137,18 @@ class Polygon extends Scoord3D {
 
 class Circle extends Scoord3D {
 
-  constructor(coordinates) {
-    super()
-    if (!Array.isArray(coordinates)) {
+  constructor(options) {
+    super({referencedFrameOfReferenceUID: options.referencedFrameOfReferenceUID})
+    if (!Array.isArray(options.coordinates)) {
       throw new Error('coordinates of Circle must be an array')
     }
-    if (coordinates.length < 2) {
+    if (options.coordinates.length < 2) {
       throw new Error('coordinates of Circle must be an array of length 2')
     }
-    if(coordinates.find(c => c.length !== 3)!== undefined){
+    if(options.coordinates.find(c => c.length !== 3)!== undefined){
       throw new Error('coordinates of Circle must be a list or size two with points of length 3')
     }
-    this[_coordinates] = coordinates
+    this[_coordinates] = options.coordinates
   }
 
   get graphicData() {
@@ -166,22 +168,22 @@ class Circle extends Scoord3D {
 
 class Ellipse extends Scoord3D {
 
-  constructor(majorAxisEndpointCoordinates, minorAxisEndpointCoordinates) {
-    super()
-    if (!Array.isArray(majorAxisEndpointCoordinates)) {
+  constructor(options) {
+    super({referencedFrameOfReferenceUID: options.referencedFrameOfReferenceUID})
+    if (!Array.isArray(options.majorAxisEndpointCoordinates)) {
       throw new Error('majorAxisEndpointCoordinates of Ellipse must be an array')
     }
-    if (!Array.isArray(minorAxisEndpointCoordinates)) {
+    if (!Array.isArray(options.minorAxisEndpointCoordinates)) {
       throw new Error('minorAxisEndpointCoordinates of Ellipse must be an array')
     }
-    if (majorAxisEndpointCoordinates.length !== 2) {
+    if (options.majorAxisEndpointCoordinates.length !== 2) {
       throw new Error('majorAxisEndpointCoordinates coordinates of Ellipse must be an array of length 2')
     }
-    if (minorAxisEndpointCoordinates.length !== 2) {
+    if (options.minorAxisEndpointCoordinates.length !== 2) {
       throw new Error('minorAxisEndpointCoordinates coordinates of Ellipse must be an array of length 2')
     }
-    this[_majorAxisEndpointCoordinates] = majorAxisEndpointCoordinates
-    this[_minorAxisEndpointCoordinates] = minorAxisEndpointCoordinates
+    this[_majorAxisEndpointCoordinates] = options.majorAxisEndpointCoordinates
+    this[_minorAxisEndpointCoordinates] = options.minorAxisEndpointCoordinates
   }
 
   get graphicData() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+function generateUuid() {
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  )
+}
+
+export { generateUuid };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,21 @@
-function generateUuid() {
-  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
+function generateUID() {
+  /*
+   * http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_B.2.html
+   * https://www.itu.int/rec/T-REC-X.667-201210-I/en
+   *  A UUID can be represented as a single integer value.
+   * To obtain the single integer value of the UUID, the 16 octets of the
+   * binary representation shall be treated as an unsigned integer encoding
+   * with the most significant bit of the integer encoding as the most
+   * significant bit (bit 7) of the first of the sixteen octets (octet 15) and
+   * the least significant bit as the least significant bit (bit 0) of the last
+   * of the sixteen octets (octet 0).
+  */
+  // FIXME: This is not a valid UUID!
+  let uid = '2.25.' + Math.floor(1 + Math.random() * 9);
+  while (uid.length < 44) {
+    uid += Math.floor(1 + Math.random() * 10);
+  }
+  return uid;
 }
 
-export { generateUuid };
+export { generateUID };

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -11,78 +11,81 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
 
     let viewer;
     const properties = {};
-    const circle = new dicomMicroscopyViewer.scoord3d.Circle({
+    const ellipse = new dicomMicroscopyViewer.scoord3d.Ellipse({
       coordinates: [
-        [8.1036, -9.3211, 1], [8.4463, -9.3211, 1]
+        [8.0, 9.2, 1],
+        [8.4, 9.2, 1],
+        [8.2, 9.0, 1],
+        [8.2, 9.4, 1]
       ],
-      referencedFrameOfReferenceUID: '1.2.3'
+      frameOfReferenceUID: '1.2.3'
     });
     const point = new dicomMicroscopyViewer.scoord3d.Point({
-      coordinates: [9.0467, -8.7631, 1],
-      referencedFrameOfReferenceUID: '1.2.3'
+      coordinates: [9.0467, 8.7631, 1],
+      frameOfReferenceUID: '1.2.3'
     });
     const box = new dicomMicroscopyViewer.scoord3d.Polyline({
       coordinates: [
-        [8.8824, -8.8684, 1],
-        [9.2255, -9.9634, 1],
-        [10.3205, -9.6203, 1],
-        [9.9774, -8.5253, 1],
-        [8.8824, -8.8684, 1]
+        [8.8824, 8.8684, 1],
+        [9.2255, 9.9634, 1],
+        [10.3205, 9.6203, 1],
+        [9.9774, 8.5253, 1],
+        [8.8824, 8.8684, 1]
       ],
-      referencedFrameOfReferenceUID: '1.2.3'
+      frameOfReferenceUID: '1.2.3'
     })
     const polygon = new dicomMicroscopyViewer.scoord3d.Polyline({
       coordinates: [
-        [7.8326, -8.4428, 1],
-        [7.1919, -7.9169, 1],
-        [8.7772, -7.2831, 1],
-        [7.8326, -8.4428, 1]
+        [7.8326, 8.4428, 1],
+        [7.1919, 7.9169, 1],
+        [8.7772, 7.2831, 1],
+        [7.8326, 8.4428, 1]
       ],
-      referencedFrameOfReferenceUID: '1.2.3'
+      frameOfReferenceUID: '1.2.3'
     })
     const freehandPolygon = new dicomMicroscopyViewer.scoord3d.Polyline({
       coordinates: [
-        [6.9340, -7.0669, 1],
-        [6.9340, -7.0669, 1],
-        [6.9189, -7.0216, 1],
-        [6.9114, -6.9973, 1],
-        [6.9114, -6.9797, 1],
-        [6.9139, -6.9621, 1],
-        [6.9216, -6.9470, 1],
-        [6.9292, -6.9344, 1],
-        [6.9419, -6.9294, 1],
-        [6.9496, -6.9269, 1],
-        [6.9597, -6.9243, 1],
-        [6.9674, -6.9243, 1],
-        [6.9674, -6.9243, 1],
-        [6.9340, -7.0669, 1]
+        [6.9340, 7.0669, 1],
+        [6.9340, 7.0669, 1],
+        [6.9189, 7.0216, 1],
+        [6.9114, 6.9973, 1],
+        [6.9114, 6.9797, 1],
+        [6.9139, 6.9621, 1],
+        [6.9216, 6.9470, 1],
+        [6.9292, 6.9344, 1],
+        [6.9419, 6.9294, 1],
+        [6.9496, 6.9269, 1],
+        [6.9597, 6.9243, 1],
+        [6.9674, 6.9243, 1],
+        [6.9674, 6.9243, 1],
+        [6.9340, 7.0669, 1]
       ],
-      referencedFrameOfReferenceUID: '1.2.3'
+      frameOfReferenceUID: '1.2.3'
     })
     const line = new dicomMicroscopyViewer.scoord3d.Polyline({
       coordinates: [
-        [7.0442, -7.5295, 1],
-        [7.6725, -7.0580, 1]
+        [7.0442, 7.5295, 1],
+        [7.6725, 7.0580, 1]
       ],
-      referencedFrameOfReferenceUID: '1.2.3'
+      frameOfReferenceUID: '1.2.3'
     })
     const freeHandLine = new dicomMicroscopyViewer.scoord3d.Polyline({
       coordinates: [
-        [6.6769, -9.1169, 1],
-        [6.6769, -9.1169, 1],
-        [6.6668, -9.1119, 1],
-        [6.6567, -9.1043, 1],
-        [6.6366, -9.0817, 1],
-        [6.6182, -9.0423, 1],
-        [6.6182, -9.0322, 1],
-        [6.6182, -9.0197, 1],
-        [6.6233, -9.0096, 1],
-        [6.6258, -9.0020, 1],
-        [6.6284, -8.9995, 1],
-        [6.6334, -8.9945, 1],
-        [6.6360, -8.9945, 1]
+        [6.6769, 9.1169, 1],
+        [6.6769, 9.1169, 1],
+        [6.6668, 9.1119, 1],
+        [6.6567, 9.1043, 1],
+        [6.6366, 9.0817, 1],
+        [6.6182, 9.0423, 1],
+        [6.6182, 9.0322, 1],
+        [6.6182, 9.0197, 1],
+        [6.6233, 9.0096, 1],
+        [6.6258, 9.0020, 1],
+        [6.6284, 8.9995, 1],
+        [6.6334, 8.9945, 1],
+        [6.6360, 8.9945, 1]
       ],
-      referencedFrameOfReferenceUID: '1.2.3'
+      frameOfReferenceUID: '1.2.3'
     })
 
     before(() => {
@@ -97,47 +100,47 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         assert.deepEqual(viewer.getROI(0), {});
     })
 
-    it('should create a Circle ROI and return it back successfuly', () => {
-        const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : circle, properties});
-        viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData[0], circle.graphicData[0]);
-        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData[1], circle.graphicData[1]);
-    })
-
     it('should create a Point ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : point, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(1).scoord3d.graphicData, point.graphicData);
+        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData, point.graphicData);
     })
 
     it('should create a Box ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : box, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(2).scoord3d.graphicData, box.graphicData);
+        assert.deepEqual(viewer.getROI(1).scoord3d.graphicData, box.graphicData);
     })
 
     it('should create a Polygon ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : polygon, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(3).scoord3d.graphicData, polygon.graphicData);
+        assert.deepEqual(viewer.getROI(2).scoord3d.graphicData, polygon.graphicData);
     })
 
     it('should create a Freehand Polygon ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : freehandPolygon, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(4).scoord3d.graphicData, freehandPolygon.graphicData);
+        assert.deepEqual(viewer.getROI(3).scoord3d.graphicData, freehandPolygon.graphicData);
     })
 
     it('should create a Line ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : line, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(5).scoord3d.graphicData, line.graphicData);
+        assert.deepEqual(viewer.getROI(4).scoord3d.graphicData, line.graphicData);
     })
 
     it('should create a FreehandLine ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : freeHandLine, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(6).scoord3d.graphicData, freeHandLine.graphicData);
+        assert.deepEqual(viewer.getROI(5).scoord3d.graphicData, freeHandLine.graphicData);
+    })
+
+    it('should create an Ellipse ROI and return it back successfuly', () => {
+        const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : ellipse, properties});
+        viewer.addROI(roi);
+        assert.deepEqual(viewer.getROI(6).scoord3d.graphicData[0], ellipse.graphicData[0]);
+        assert.deepEqual(viewer.getROI(6).scoord3d.graphicData[1], ellipse.graphicData[1]);
     })
 
     it('should return all ROIs created up to now', () => {
@@ -145,28 +148,32 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         assert.equal(rois.length, 7)
     })
 
-    it('should be able to remove the circle ROI', () => {
-        let rois = viewer.getAllROIs();
-        assert.equal(rois.length, 7);
-        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData[0], circle.graphicData[0]);
-        viewer.removeROI(0);
-        rois = viewer.getAllROIs();
-        assert.equal(rois.length, 6);
-        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData, point.graphicData);
-    })
-
     it('should be able to modify the point ROI', () => {
         let rois = viewer.getAllROIs();
         assert.deepEqual(rois[0].scoord3d.coordinates, point.coordinates);
         const newPoint = new dicomMicroscopyViewer.scoord3d.Point({
           coordinates: [0, 10, 1],
-          referencedFrameOfReferenceUID: '1.2.3'
+          frameOfReferenceUID: '1.2.3'
         });
         const newPointRoi = new dicomMicroscopyViewer.roi.ROI({scoord3d : newPoint, properties});
         viewer.updateROI(0, newPointRoi);
         rois = viewer.getAllROIs();
         assert.deepEqual(rois[0].scoord3d.coordinates, newPoint.coordinates);
+        // Change back to not affect downstream tests
+        const oldPointRoi = new dicomMicroscopyViewer.roi.ROI({scoord3d : point, properties});
+        viewer.updateROI(0, oldPointRoi);
     })
+
+    it('should be able to remove the point ROI', () => {
+        let rois = viewer.getAllROIs();
+        assert.equal(rois.length, 7);
+        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData, point.graphicData);
+        viewer.removeROI(0);
+        rois = viewer.getAllROIs();
+        assert.equal(rois.length, 6);
+        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData, box.graphicData);
+    })
+
 
     it('should throw an error if uid of ROI is undefined', () => {
         assert.throws( function() {

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -96,51 +96,51 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         });
     })
 
-    it('should return {} if there is no drawing', () => {
-        assert.deepEqual(viewer.getROI(0), {});
+    it('should return [] if there is no drawing', () => {
+        assert.deepEqual(viewer.getAllROIs(), []);
     })
 
     it('should create a Point ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : point, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData, point.graphicData);
+        assert.deepEqual(viewer.getROI(roi.uid).scoord3d.graphicData, point.graphicData);
     })
 
     it('should create a Box ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : box, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(1).scoord3d.graphicData, box.graphicData);
+        assert.deepEqual(viewer.getROI(roi.uid).scoord3d.graphicData, box.graphicData);
     })
 
     it('should create a Polygon ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : polygon, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(2).scoord3d.graphicData, polygon.graphicData);
+        assert.deepEqual(viewer.getROI(roi.uid).scoord3d.graphicData, polygon.graphicData);
     })
 
     it('should create a Freehand Polygon ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : freehandPolygon, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(3).scoord3d.graphicData, freehandPolygon.graphicData);
+        assert.deepEqual(viewer.getROI(roi.uid).scoord3d.graphicData, freehandPolygon.graphicData);
     })
 
     it('should create a Line ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : line, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(4).scoord3d.graphicData, line.graphicData);
+        assert.deepEqual(viewer.getROI(roi.uid).scoord3d.graphicData, line.graphicData);
     })
 
     it('should create a FreehandLine ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : freeHandLine, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(5).scoord3d.graphicData, freeHandLine.graphicData);
+        assert.deepEqual(viewer.getROI(roi.uid).scoord3d.graphicData, freeHandLine.graphicData);
     })
 
     it('should create an Ellipse ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : ellipse, properties});
         viewer.addROI(roi);
-        assert.deepEqual(viewer.getROI(6).scoord3d.graphicData[0], ellipse.graphicData[0]);
-        assert.deepEqual(viewer.getROI(6).scoord3d.graphicData[1], ellipse.graphicData[1]);
+        assert.deepEqual(viewer.getROI(roi.uid).scoord3d.graphicData[0], ellipse.graphicData[0]);
+        assert.deepEqual(viewer.getROI(roi.uid).scoord3d.graphicData[1], ellipse.graphicData[1]);
     })
 
     it('should return all ROIs created up to now', () => {
@@ -148,30 +148,14 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         assert.equal(rois.length, 7)
     })
 
-    it('should be able to modify the point ROI', () => {
-        let rois = viewer.getAllROIs();
-        assert.deepEqual(rois[0].scoord3d.coordinates, point.coordinates);
-        const newPoint = new dicomMicroscopyViewer.scoord3d.Point({
-          coordinates: [0, 10, 1],
-          frameOfReferenceUID: '1.2.3'
-        });
-        const newPointRoi = new dicomMicroscopyViewer.roi.ROI({scoord3d : newPoint, properties});
-        viewer.updateROI(0, newPointRoi);
-        rois = viewer.getAllROIs();
-        assert.deepEqual(rois[0].scoord3d.coordinates, newPoint.coordinates);
-        // Change back to not affect downstream tests
-        const oldPointRoi = new dicomMicroscopyViewer.roi.ROI({scoord3d : point, properties});
-        viewer.updateROI(0, oldPointRoi);
-    })
-
     it('should be able to remove the point ROI', () => {
         let rois = viewer.getAllROIs();
         assert.equal(rois.length, 7);
-        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData, point.graphicData);
-        viewer.removeROI(0);
+        assert.deepEqual(viewer.getROI(rois[0].uid).scoord3d.graphicData, point.graphicData);
+        viewer.removeROI(rois[0].uid);
         rois = viewer.getAllROIs();
         assert.equal(rois.length, 6);
-        assert.deepEqual(viewer.getROI(0).scoord3d.graphicData, box.graphicData);
+        assert.deepEqual(viewer.getROI(rois[0].uid).scoord3d.graphicData, box.graphicData);
     })
 
 

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -11,22 +11,37 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
 
     let viewer;
     const properties = {};
-    const circle = new dicomMicroscopyViewer.scoord3d.Circle([[8.1036, -9.3211, 1], [8.4463, -9.3211, 1]]);
-    const point = new dicomMicroscopyViewer.scoord3d.Point([9.0467, -8.7631, 1]);
-    const box = new dicomMicroscopyViewer.scoord3d.Polyline([
+    const circle = new dicomMicroscopyViewer.scoord3d.Circle({
+      coordinates: [
+        [8.1036, -9.3211, 1], [8.4463, -9.3211, 1]
+      ],
+      referencedFrameOfReferenceUID: '1.2.3'
+    });
+    const point = new dicomMicroscopyViewer.scoord3d.Point({
+      coordinates: [9.0467, -8.7631, 1],
+      referencedFrameOfReferenceUID: '1.2.3'
+    });
+    const box = new dicomMicroscopyViewer.scoord3d.Polyline({
+      coordinates: [
         [8.8824, -8.8684, 1],
         [9.2255, -9.9634, 1],
         [10.3205, -9.6203, 1],
         [9.9774, -8.5253, 1],
         [8.8824, -8.8684, 1]
-    ])
-    const polygon = new dicomMicroscopyViewer.scoord3d.Polyline([
+      ],
+      referencedFrameOfReferenceUID: '1.2.3'
+    })
+    const polygon = new dicomMicroscopyViewer.scoord3d.Polyline({
+      coordinates: [
         [7.8326, -8.4428, 1],
         [7.1919, -7.9169, 1],
         [8.7772, -7.2831, 1],
         [7.8326, -8.4428, 1]
-    ])
-    const freehandPolygon = new dicomMicroscopyViewer.scoord3d.Polyline([
+      ],
+      referencedFrameOfReferenceUID: '1.2.3'
+    })
+    const freehandPolygon = new dicomMicroscopyViewer.scoord3d.Polyline({
+      coordinates: [
         [6.9340, -7.0669, 1],
         [6.9340, -7.0669, 1],
         [6.9189, -7.0216, 1],
@@ -41,12 +56,18 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         [6.9674, -6.9243, 1],
         [6.9674, -6.9243, 1],
         [6.9340, -7.0669, 1]
-    ])
-    const line = new dicomMicroscopyViewer.scoord3d.Polyline([
+      ],
+      referencedFrameOfReferenceUID: '1.2.3'
+    })
+    const line = new dicomMicroscopyViewer.scoord3d.Polyline({
+      coordinates: [
         [7.0442, -7.5295, 1],
         [7.6725, -7.0580, 1]
-    ])
-    const freeHandLine = new dicomMicroscopyViewer.scoord3d.Polyline([
+      ],
+      referencedFrameOfReferenceUID: '1.2.3'
+    })
+    const freeHandLine = new dicomMicroscopyViewer.scoord3d.Polyline({
+      coordinates: [
         [6.6769, -9.1169, 1],
         [6.6769, -9.1169, 1],
         [6.6668, -9.1119, 1],
@@ -60,7 +81,9 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         [6.6284, -8.9995, 1],
         [6.6334, -8.9945, 1],
         [6.6360, -8.9945, 1]
-    ])
+      ],
+      referencedFrameOfReferenceUID: '1.2.3'
+    })
 
     before(() => {
         viewer = new dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer({
@@ -86,7 +109,7 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         viewer.addROI(roi);
         assert.deepEqual(viewer.getROI(1).scoord3d.graphicData, point.graphicData);
     })
-    
+
     it('should create a Box ROI and return it back successfuly', () => {
         const roi = new dicomMicroscopyViewer.roi.ROI({scoord3d : box, properties});
         viewer.addROI(roi);
@@ -121,7 +144,7 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         const rois = viewer.getAllROIs();
         assert.equal(rois.length, 7)
     })
-    
+
     it('should be able to remove the circle ROI', () => {
         let rois = viewer.getAllROIs();
         assert.equal(rois.length, 7);
@@ -135,7 +158,10 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
     it('should be able to modify the point ROI', () => {
         let rois = viewer.getAllROIs();
         assert.deepEqual(rois[0].scoord3d.coordinates, point.coordinates);
-        const newPoint = new dicomMicroscopyViewer.scoord3d.Point([0, 10, 1]);
+        const newPoint = new dicomMicroscopyViewer.scoord3d.Point({
+          coordinates: [0, 10, 1],
+          referencedFrameOfReferenceUID: '1.2.3'
+        });
         const newPointRoi = new dicomMicroscopyViewer.roi.ROI({scoord3d : newPoint, properties});
         viewer.updateROI(0, newPointRoi);
         rois = viewer.getAllROIs();

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -168,4 +168,15 @@ describe('dicomMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer', ()=> {
         assert.deepEqual(rois[0].scoord3d.coordinates, newPoint.coordinates);
     })
 
+    it('should throw an error if uid of ROI is undefined', () => {
+        assert.throws( function() {
+          const roid = new dicomMicroscopyViewer.roi.ROI({scoord3d : point, uid: undefined, properties})
+        }, Error )
+    })
+
+    it('should throw an error if uid of ROI is null', () => {
+        assert.throws( function() {
+          const roid = new dicomMicroscopyViewer.roi.ROI({scoord3d : point, uid: null, properties})
+        }, Error )
+    })
 });


### PR DESCRIPTION
This PR adds a `uid` property to `ROI` objects, which will facilitate tracking of regions and measurement groups.