### PR TITLE
fix(api.js): Update DICOMWebClient usage to use mediatypes array format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1126,9 +1126,9 @@
       }
     },
     "dicomweb-client": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/dicomweb-client/-/dicomweb-client-0.4.2.tgz",
-      "integrity": "sha512-Raf2SVjWDrNaVIVt4CmfXWdKVacyEX5ux+pY2Qop0mhluG+OiCkbnESljz4PjglFRnprETEk6C0ELGDru0haew=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/dicomweb-client/-/dicomweb-client-0.5.0.tgz",
+      "integrity": "sha512-+DKnGLBCAp1HC7f1c3JpJ0j4VkV4irO0O/KHQjK8VXMAlBi7OFS3ccgPcJrslWyT7Y8sPPQL5Cu7AXJzG6i8lQ=="
     },
     "diff": {
       "version": "3.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dicom-microscopy-viewer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1126,9 +1126,9 @@
       }
     },
     "dicomweb-client": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/dicomweb-client/-/dicomweb-client-0.5.0.tgz",
-      "integrity": "sha512-+DKnGLBCAp1HC7f1c3JpJ0j4VkV4irO0O/KHQjK8VXMAlBi7OFS3ccgPcJrslWyT7Y8sPPQL5Cu7AXJzG6i8lQ=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/dicomweb-client/-/dicomweb-client-0.5.1.tgz",
+      "integrity": "sha512-/4h84Nda6lWsVnAsWFuWv0mJPSDzZDda3KNcpMmbQcK7XVvGnwvG3dKwDuRh++9YOC+xbqgk2PkULlStV0X3RQ=="
     },
     "diff": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dicom-microscopy-viewer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Interactive web-based viewer for DICOM Microscopy Images",
   "main": "build/dicom-microscopy-viewer.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "rollup-plugin-node-resolve": "^3.3.0"
   },
   "dependencies": {
-    "dicomweb-client": "^0.5.0",
+    "dicomweb-client": "^0.5.1",
     "ol": "^5.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rollup-plugin-node-resolve": "^3.3.0"
   },
   "dependencies": {
-    "dicomweb-client": "^0.4.2",
+    "dicomweb-client": "^0.5.0",
     "ol": "^5.3.0"
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -474,31 +474,31 @@ class VLWholeSlideMicroscopyImageViewer {
         const frameNumbers = DICOMwebClient.utils.getFrameNumbersFromUri(src);
         const img = tile.getImage();
         if (options.retrieveRendered) {
-          const mimeType = 'image/png';
+          const mediaType = 'image/png';
           const retrieveOptions = {
             studyInstanceUID,
             seriesInstanceUID,
             sopInstanceUID,
             frameNumbers,
-            mimeType
+            mediaTypes: [{ mediaType }]
           };
           options.client.retrieveInstanceFramesRendered(retrieveOptions).then((renderedFrame) => {
-            const blob = new Blob([renderedFrame], {type: mimeType});
+            const blob = new Blob([renderedFrame], {type: mediaType});
             img.src = window.URL.createObjectURL(blob);
           });
         } else {
           // TODO: support "image/jp2" and "image/jls"
-          const mimeType = 'image/jpeg';
+          const mediaType = 'image/jpeg';
 
           const retrieveOptions = {
             studyInstanceUID,
             seriesInstanceUID,
             sopInstanceUID,
             frameNumbers,
-            mimeType: `${mimeType}; transfer-syntax=1.2.840.10008.1.2.4.50`
+            mediaTypes: [{mediaType, transferSyntaxUID: '1.2.840.10008.1.2.4.50'}]
           };
           options.client.retrieveInstanceFrames(retrieveOptions).then((rawFrames) => {
-            const blob = new Blob(rawFrames, {type: mimeType});
+            const blob = new Blob(rawFrames, {type: mediaType});
             img.src = window.URL.createObjectURL(blob);
           });
         }


### PR DESCRIPTION
Addresses #32.

**Note:** This depends on https://github.com/dcmjs-org/dicomweb-client/pull/16, so we shouldn't merge this until that PR is merged and we can depend on an updated version of dicomweb-client. For that reason, this is marked as a Draft PR.

This is a bit of deja vu from this issue (https://github.com/dcmjs-org/dicom-microscopy-viewer/pull/23).

This just switches from the hardcoded mimetype string to a hardcoded mediatypes array. Nothing changes to the end user, but it will fix the quotation mark issue we have that is breaking usage of this library with Google Cloud Healthcare (#32).
